### PR TITLE
Fix repository typo in About page

### DIFF
--- a/dashboard/src/components/About.js
+++ b/dashboard/src/components/About.js
@@ -47,7 +47,7 @@ const About = () => {
           rel="noreferrer noopener"
           className="text-blue-600 hover:text-blue-800 visited:text-purple-600"
         >
-          respository
+          repository
         </a>{" "}
         on GitHub.
       </p>


### PR DESCRIPTION
## Summary
- correct misspelled anchor text on the About page

## Testing
- `npm test --silent --max-workers=2` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856dc8dce98832c870acb6c760aa583